### PR TITLE
Add a z-index to popover container

### DIFF
--- a/src/Popover.svelte
+++ b/src/Popover.svelte
@@ -474,6 +474,10 @@
   .popover-hover-bridge {
     position: absolute;
   }
+  
+  .svelte-easy-popover {
+    z-index: var(--z-index, 1);
+  }
 
   :global([data-popper-placement^="top"]).svelte-easy-popover
     .popover-hover-bridge {


### PR DESCRIPTION
Adding a z-index on the slot does not bump the layer if we have a relative element on the same position:

https://svelte.dev/repl/468a9541bd444c65aa1ded60627541d9?version=3.44.0

The only solution I see is adding a z-index on the container and make it parameterized.